### PR TITLE
fix openConnection to use the more flexible API

### DIFF
--- a/System/LibVirt/Foreign.chs
+++ b/System/LibVirt/Foreign.chs
@@ -247,8 +247,14 @@ data ConnectCredential = ConnectCredential {
 
 {# fun virInitialize as initialize { } -> `Int' exceptionOnMinusOne* #}
 
-{# fun virConnectOpen as openConnection
-    { `String' } -> `Connection' ptrToConnection* #}
+foreign import ccall "&" virConnectAuthPtrDefault :: Ptr (Ptr ())
+
+openConnection :: String -> IO Connection
+openConnection uri =
+  withCString uri $ \str -> do
+    authPtr <- peek virConnectAuthPtrDefault
+    connPtr <- {# call virConnectOpenAuth #} str authPtr 0
+    ptrToConnection connPtr
 
 {# fun virConnectClose as closeConnection
     { connectionToPtr `Connection' } -> `Int' exceptionOnMinusOne* #}

--- a/libvirt-hs.cabal
+++ b/libvirt-hs.cabal
@@ -1,5 +1,5 @@
 Name:                libvirt-hs
-Version:             0.2.0
+Version:             0.2.1
 
 Synopsis:            FFI bindings to libvirt virtualization API (http://libvirt.org)
 


### PR DESCRIPTION
openConnection will now prompt for username/password when connecting to ESXi. Tested with VMware vSphere Hypervisor 6.
